### PR TITLE
Fix cpubar for cpu0

### DIFF
--- a/rightside.conf
+++ b/rightside.conf
@@ -88,7 +88,7 @@ ${if_match ${cpu cpu0} > 50}${color4}${else}\
 ${if_match ${cpu cpu0} > 25}${color5}${else}\
 ${if_match ${cpu cpu0} > 10}${color6}${else}\
 ${color1}${endif}${endif}${endif}${endif}${endif}\
-${cpubar cpu1 10,120}${alignr}${cpu cpu0}%${color0}
+${cpubar cpu0 10,120}${alignr}${cpu cpu0}%${color0}
     1 ${if_match ${cpu cpu1} > 85}${color2}${else}\
 ${if_match ${cpu cpu1} > 75}${color3}${else}\
 ${if_match ${cpu cpu1} > 50}${color4}${else}\


### PR DESCRIPTION
The cpu bar for cpu 0 was using cpu 1's bar.